### PR TITLE
Slaves must be able to NOTIFY other Secondaries

### DIFF
--- a/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
+++ b/dns/pfSense-pkg-bind9/files/usr/local/pkg/bind.inc
@@ -428,7 +428,6 @@ EOD;
 						$bind_conf .= "\t\tmasters { $zoneipslave; };\n";
 						$bind_conf .= "\t\tallow-query { $zoneallowquery; };\n";
 						$bind_conf .= "\t\tallow-transfer { $zoneallowtransfer; };\n";
-						$bind_conf .= "\t\tnotify no;\n";
 						break;
 					case 'forward':
 						$bind_conf .= "\t\tforward only;\n";


### PR DESCRIPTION
The default behaviour of BIND is that Slaves will send NOTIFY to other Secondaries. In pfSense, `notify no` in all Slave zones prevents this default behaviour, which is unexpected and looks like a bug until inspecting named.conf.

There is no way to overcome this `notify no`, even when putting `notify explicit {}` into Custom Options of surrounding views for example. Even worse, BIND will throw an error when putting another `notify yes|explicit {}` into Custom Options of zones, and named will subsequently fail to start.

Admins who do want to prevent their Slaves from sending NOTIFY should put `notify no` explicitly into the Custom Options.
In my use case however, I need my Slaves to send NOTIFY to I/AXFR servers of the global anycast Secondaries at DNSMadeEasy using in the Custom Options of the view `notify explicit;
also-notify {
 208.94.147.135;
 208.94.150.198;
 63.219.151.12;
};`

This only works with the proposed PR.
